### PR TITLE
tirex-tiledir-check should not truncate stats file on start

### DIFF
--- a/bin/tirex-tiledir-check
+++ b/bin/tirex-tiledir-check
@@ -35,6 +35,7 @@ use File::stat;
 use Getopt::Long qw( :config gnu_getopt );
 use IO::File;
 use IO::Handle;
+use IO::Seekable;
 use JSON;
 use List::Util qw();
 use Pod::Usage qw();
@@ -81,7 +82,7 @@ if ($opts{'stats'} eq '-')
 }
 elsif ($opts{'stats'})
 {
-    $fh_stats = IO::File->new($opts{'stats'}, 'w') or die("Can't open stats file '$opts{'stats'}': $!\n");
+    $fh_stats = IO::File->new($opts{'stats'}, 'a') or die("Can't open stats file '$opts{'stats'}': $!\n");
 }
 
 die("missing map parameter\n") unless (defined $ARGV[0]);
@@ -129,6 +130,11 @@ foreach my $dir (@directories)
 if ($fh_stats)
 {
     my $json = JSON::to_json(\%stats, { pretty => 1 });
+    unless ($opts{'stats'} eq '-')
+    {
+        $fh_stats->truncate(0);
+        $fh_stats->seek(0, SEEK_SET);
+    }
     $fh_stats->print("$json\n");
 }
 


### PR DESCRIPTION
The fact that tirex-tiledir-check truncates the stats-output-file right after start creates ugly holes in our munin graphs. As the gathering of the stats takes some time, the file is simply empty for a few minutes, thereby creating the holes.
This PR delays truncating the file until the new stats have been gathered.
(This PR is copied over from an issue in the old trac.openstreetmap.org)